### PR TITLE
set unit_concept_id = null when source unit value is null

### DIFF
--- a/docs/CPRD/CPRD_Test_STEM.md
+++ b/docs/CPRD/CPRD_Test_STEM.md
@@ -47,7 +47,7 @@ As discussed above, the lab tests in the CPRD Test table are given both an entit
 | source_concept_id | test_int.read_code |Map the read code to a concept id using the [SOURCE_TO_SOURCE](https://github.com/OHDSI/ETL-LambdaBuilder/blob/master/docs/Standard%20Queries/SOURCE_TO_SOURCE.sql) query to map the read code to a source concept id with the following filters:<br><br> Where source_vocabulary_id = 'Read' <br><br>*BE CAREFUL - READ CODES ARE CASE SENSITIVE*. If there is no mapping available set source_concept_id to zero.| This maps the read code on the record to a concept id so that both the test (enttype) and read codes are mapped.|
 | type_concept_id |  | Use **32856** - Lab  | |
 | operator_concept_id |  | Map test_int.operator to a standard concept_id using the following logic:   <br><br> <	 as  4171756 <br> <= 	as  4171754 <br> =	as  4172703 <br> >	as  4172704 <br> >=	as  4172704  <br><br>  This can also be done by joining to the CONCEPT table where operator = concept_name and domain = 'Meas Value Operator' and standard_concept = 'S' and invalid_reason is NULL.  | |
-| unit_concept_id |  | Look up test_int.unit in the CONCEPT table where vocabulary_id = 'UCUM' and standard_concept = 'S' and invalid_reason is NULL.  |  |
+| unit_concept_id |  | Look up test_int.unit in the CONCEPT table where vocabulary_id = 'UCUM' and standard_concept = 'S' and invalid_reason is NULL.  | Set UNIT_CONCEPT_ID = NULL when the source unit value is NULL;<br>Set UNIT_CONCEPT_ID = 0 when source unit value is not NULL but doesn't have a mapping |
 | unit_source_value | test_int.unit |  |  |
 | start_date | test_int.eventdate |  |    |
 | end_date |  |  |  |

--- a/docs/IBM_CCAE_MDCR/CCAE_MDCR_stem_lab.md
+++ b/docs/IBM_CCAE_MDCR/CCAE_MDCR_stem_lab.md
@@ -85,7 +85,7 @@ IF RESULT > -999999.99999 THEN DO;
 | SIG | - | NULL | - |
 | STOP_REASON | - | NULL | - |
 | UNIQUE_DEVICE_ID | - | NULL | - |
-| UNIT_CONCEPT_ID | RESUNIT | Use the <a href="https://ohdsi.github.io/CommonDataModel/sqlScripts.html">Source-to-Standard Query</a>.<br><br> Filters:<br>`WHERE SOURCE_VOCABULARY_ID IN ('UCUM')`<br>  `AND TARGET_VOCABULARY_ID IN ('UCUM')`<br>`AND TARGET_INVALID_REASON IS NULL`<br><br>If you do not get a map from UCUM use the JNJ_UNIT vocabulary. | - |
+| UNIT_CONCEPT_ID | RESUNIT | Use the <a href="https://ohdsi.github.io/CommonDataModel/sqlScripts.html">Source-to-Standard Query</a>.<br><br> Filters:<br>`WHERE SOURCE_VOCABULARY_ID IN ('UCUM')`<br>  `AND TARGET_VOCABULARY_ID IN ('UCUM')`<br>`AND TARGET_INVALID_REASON IS NULL`<br><br>If you do not get a map from UCUM use the JNJ_UNIT vocabulary.<br><br> Set UNIT_CONCEPT_ID = NULL when the source unit value is NULL;<br>Set UNIT_CONCEPT_ID = 0 when source unit value is not NULL but doesn't have a mapping| - |
 | UNIT_SOURCE_VALUE | RESUNIT | RESUNIT as it appears in the **LAB** table | - |
 | VALUE_AS_CONCEPT_ID | RESLTCAT <br> ABNORMAL | Refer to logic above for defining this field. After assigning the above logic, then map RESLTCAT to a Standard Concept using the SOURCE_TO_STANDARD query with the filter<br/><br/>**LOINC_CD**<br> WHERE SOURCE_VOCABULARY_ID IN ('LOINC') AND TARGET_STANDARD_CONCEPT ='S' AND TARGET_INVALID_REASON IS NULL, mapping to SOURCE_CODE_DESCRIPTION instead of SOURCE_CODE| - |
 | VALUE_AS_NUMBER | RESULT | Put any numerical values in the RESULT field here. All values in the RESULT field as they show up in the native will be present in VALUE_SOURCE_VALUE field of the CDM.<br><br>For the following LOINCs (3142-7, 29463-7, 3141-9) if the RESULT > 100000 and the last digits are 0000 and RESUNIT = ‘LBS’, trim the last four digits 0000. | - |
@@ -105,6 +105,12 @@ IF RESULT > -999999.99999 THEN DO;
 | QUALIFIER_SOURCE_VALUE | - | NULL | - |
 
 ## Change Log
+
+### September 29, 2022
+* Units rule changed:
+   *  Set UNIT_CONCEPT_ID = NULL when the source unit value is NULL
+   *  Set UNIT_CONCEPT_ID =0 when source unit value is not NULL but doesn't have a mapping
+
 ### July 15, 2021
 * Mapping added to VALUE_AS_CONCEPT_ID
 

--- a/docs/JMDC/JMDC_Measurement.md
+++ b/docs/JMDC/JMDC_Measurement.md
@@ -30,7 +30,7 @@ When an ICD10 code in the **diagnosis** table maps to a concept in the Measureme
 |     operator_concept_id    |          |          |          |
 |     value_as_number    |          |          |          |
 |     value_as_concept_id    |          |          |     From Health checkups: from mapping table. Else 4181412   (Present)    |
-|     unit_concept_id    |          |          |     From mapping table    |
+|     unit_concept_id    |          |     Set UNIT_CONCEPT_ID = NULL when the source unit value is NULL;<br>Set UNIT_CONCEPT_ID = 0 when source unit value is not NULL but doesn't have a mapping     |     From mapping table    |
 |     range_low    |          |          |     From Health checkups: take from reference file    |
 |     range_high    |          |          |     From Health checkups: take from reference file    |
 |     visit_detail_id    |          |          |          |
@@ -57,7 +57,7 @@ The **annual_health_checkup** table is a wide table with one row per date and ma
 |     operator_concept_id    |          |          |          |
 |     value_as_number    |          | Put the numeric values from the columns here         |          |
 |     value_as_concept_id    |    See mapping table for mapping the categorical answers    |          |         |
-|     unit_concept_id    |          |          |     See mapping table for the correct units  |
+|     unit_concept_id    |          |     Set UNIT_CONCEPT_ID = NULL when the source unit value is NULL;<br>Set UNIT_CONCEPT_ID = 0 when source unit value is not NULL but doesn't have a mapping     |     From mapping table    |
 |     range_low    |          |          |         |
 |     range_high    |          |          |        |
 |     visit_detail_id    |          |          |          |

--- a/docs/OPTUM_PANTHER/Optum_Panther_Labs_STEM.md
+++ b/docs/OPTUM_PANTHER/Optum_Panther_Labs_STEM.md
@@ -28,7 +28,7 @@ description: "OPTUM EHR Labs table to STEM"
 | source_concept_id |0 || |
 | type_concept_id | 32856  | Lab result| | 
 | operator_concept_id |relative_indicator | When relative_indicator is NULL/empty, leave the value as NULL. Otherwise do as follows:<br><br>CASE WHEN relative_incicator == ‘<=’ THEN 4171754<br>CASE WHEN relative_incicator == ‘>=’ THEN 4171755<br>CASE WHEN relative_incicator == ‘<’ THEN 4171756 <br>CASE WHEN relative_incicator == ‘=’ THEN 4172703 <br>CASE WHEN relative_incicator == ‘>’ THEN 4172704<br>ELSE 0| |
-| unit_concept_id | result_unit  | Map to UCUM vocabulary using a CASE-SENSITIVE matching; if no match if found, match to the JNJ_UNITS STCM. If no match is found in either vocabulary, set this field to 0.| |
+| unit_concept_id | result_unit  | Map to UCUM vocabulary using a CASE-SENSITIVE matching; if no match if found, match to the JNJ_UNITS STCM. If no match is found in either vocabulary, set this field to 0.<br> Set UNIT_CONCEPT_ID = NULL when the source unit value is NULL| |
 | unit_source_value | result_unit | | |
 | range_high | normal_range | Parse lower bound (split on hyphen), first piece | | 
 | range_low | normal_range |Parse upper bound (split on hyphen), second piece | |

--- a/docs/Optum Clinformatics/Optum_lab_results_to_STEM.md
+++ b/docs/Optum Clinformatics/Optum_lab_results_to_STEM.md
@@ -81,7 +81,7 @@ Certain COVID-19 tests have specific text results that need to be mapped manuall
 | source_concept_id |LOINC_CD, PROC_CD|Use the SOURCE_TO_SOURCE query with the filter<br/><br/>**LOINC_CD**<br> WHERE SOURCE_VOCABULARY_ID IN ('LOINC') <br/><br/>**PROC_CD**<br> WHERE SOURCE_VOCABULARY_ID IN ('HCPCS','CPT4') |Put the SOURCE_CONCEPT_ID of the either the LOINC_CD or PROC_CD that was used to map the standard concept_id.|
 | type_concept_id |Set to 32856 (Lab)|||  
 | operator_concept_id | See the above logic to assign this value based on the first to characters of the RSLT_TXT field. |||
-| unit_concept_id | **LAB_RESULTS** RSLT_UNIT_NM |Use the SOURCE_TO_STANDARD query with the filter <br><br>Where SOURCE_VOCABULARY_ID in ('UCUM', 'JNJ_UNITS') AND TARGET_STANDARD_CONCEPT = 'S' AND TARGET_INVALID_REASON IS NULL|If there is no mapping to a standard concept then set to 0||
+| unit_concept_id | **LAB_RESULTS** RSLT_UNIT_NM |Use the SOURCE_TO_STANDARD query with the filter <br><br>Where SOURCE_VOCABULARY_ID in ('UCUM', 'JNJ_UNITS') AND TARGET_STANDARD_CONCEPT = 'S' AND TARGET_INVALID_REASON IS NULL|If there is no mapping to a standard concept then set to 0<br><br> Set UNIT_CONCEPT_ID = NULL when the source unit value is NULL|||
 | unit_source_value |**LAB_RESULTS** RSLT_UNIT_NM |||
 | start_date | **VISIT_DETAIL** VISIT_DETAIL_START_DATE||| 
 | end_date |  |||

--- a/docs/PREMIER/Premier_Measurement.md
+++ b/docs/PREMIER/Premier_Measurement.md
@@ -33,7 +33,7 @@ The field mapping is performed as follows:
 | OPERATOR_CONCEPT_ID | - | NULL |  |
 | VALUE_AS_NUMBER | - | See query below |  |
 | VALUE_AS_CONCEPT_ID | - | NULL |  |
-| UNIT_CONCEPT_ID | - | For operation time records 8550Else NULL |  |
+| UNIT_CONCEPT_ID | - | For operation time records 8550Else NULL |Set UNIT_CONCEPT_ID = NULL when the source unit value is NULL;<br>Set UNIT_CONCEPT_ID = 0 when source unit value is not NULL but doesn't have a mapping  |
 | RANGE_LOW | - | NULL |  |
 | RANGE_HIGH | - | NULL |  |
 | PROVIDER_ID | PATICD_PROC.PROC_PHYPAT.ADMPHY | When operation time PATICD_PROC.PROC_PHYElsePAT.ADMPHY |  |

--- a/docs/PREMIER/Premier_Observation.md
+++ b/docs/PREMIER/Premier_Observation.md
@@ -36,7 +36,7 @@ The field mapping is performed as follows:
 | VALUE_AS_STRING | PAT.MART_STATUSPAT.POINT_OF_ORIGINPAT.DISC_STATUSPAT.PAT_TYPE | Value_as_string only populated for Premier-specific fields mart_status, point_of_origin, disc_status, and pat_typeMarital status values populated directly from PAT.MART_STATUS as ‘M’, ‘S’, ‘O’, or ‘U’select point_of_origin_desc from poorgin pojoin pat p on p.mart_status=po.point_of_originselect disc_status from poorgin pojoin pat p on p.mart_status=po.point_of_originselect pat_type_desc from pattype pjoin pat p1 on p1.pat_type=p.pat_type | Use look up values in the text fields.  |
 | VALUE_AS_CONCEPT_ID | - | NULL |  |
 | QUALIFER_CONCEPT_ID | - | NULL |  |
-| UNIT_CONCEPT_ID | - | NULL |  |
+| UNIT_CONCEPT_ID | - | NULL | Set UNIT_CONCEPT_ID = NULL when the source unit value is NULL;<br>Set UNIT_CONCEPT_ID = 0 when source unit value is not NULL but doesn't have a mapping |
 | PROVIDER_CONCEPT_ID | PAT.ADMPHY |  |  |
 | VISIT_OCCURRENCE_ID | PAT.PAT_KEY |  |  |
 | OBSERVATION_SOURCE_VALUE | PAT.DRG\PATICD.ICD_CODE\PATCPT.CPT_CODE\CHARGE CODE | Standard charge code value:SELECT CONCAT(STD_CHG_DESC, ' / ', HOSP_CHG_DESC) AS SOURCE_VALUE FROM PATBILL AJOIN CHGMSTR B ON A.STD_CHG_CODE=B.STD_CHG_CODEJOIN hospchg C ON A.hosp_chg_id=C.hosp_chg_id |  |


### PR DESCRIPTION
Added explicit documentation of the following rules 
* Units rule changed:
   *  Set UNIT_CONCEPT_ID = NULL when the source unit value is NULL
   *  Set UNIT_CONCEPT_ID =0 when source unit value is not NULL but doesn't have a mapping
  when it is applicable