### PR TITLE
fixes and proper dates logic in Optum extended

### DIFF
--- a/docs/CPRD_Aurum/CPRD_Aurum_Observation_STEM.md
+++ b/docs/CPRD_Aurum/CPRD_Aurum_Observation_STEM.md
@@ -33,7 +33,7 @@ In the below table, only the relevant STEM fields are shown.
 | type_concept_id |  | Set all from observation as **32840** - observation recorded from EHR |  |
 | range_high | numrangehigh | |
 | range_low | numrangelow | |
-| unit_concept_id | numunitid | Lookup up the unitid in the lookup tables and use the [SOURCE_TO_STANDARD](https://github.com/OHDSI/ETL-LambdaBuilder/blob/master/docs/Standard%20Queries/SOURCE_TO_STANDARD.sql) query to map either the numunitid to standard concept(s) with the following filters: <br> <br>  Where source_vocabulary_id in ('UCUM', 'CPRD_Units')  and target_standard_concept = 'S'  and target_invalid_reason is NULL<br>When numinitid is NULL, set unit_concept_id = NULL |
+| unit_concept_id | numunitid | Lookup up the unitid in the lookup tables and use the [SOURCE_TO_STANDARD](https://github.com/OHDSI/ETL-LambdaBuilder/blob/master/docs/Standard%20Queries/SOURCE_TO_STANDARD.sql) query to map either the numunitid to standard concept(s) with the following filters: <br> <br>  Where source_vocabulary_id in ('UCUM', 'JNJ_UNITS') and target_standard_concept = 'S'  and target_invalid_reason is NULL<br>When numinitid is NULL, set unit_concept_id = NULL |
 | unit_source_value | numunitid | Lookup the unitid in the lookup tables and put the english version of the unit here |
 | value_as_number | value | |
 | value_source_value | value | |

--- a/docs/OPTUM_PANTHER/Optum_Panther_NLP_Measurement_STEM.md
+++ b/docs/OPTUM_PANTHER/Optum_Panther_NLP_Measurement_STEM.md
@@ -30,7 +30,7 @@ description: "OPTUM EHR NLP_Measurement table to STEM"
 | source_concept_id |0 || |
 | type_concept_id | 32858  | NLP| | 
 | operator_concept_id |0 | | |
-| unit_concept_id | measurement_detail | If the inbound record maps to measurement_concept_id = (Body mass index), then set the unit_concept_id to 9531 (kilogram per square meter). Otherwise, match to the JNJ_UNITS STCM. If no match is found, set this field to 0.| |
+| unit_concept_id | measurement_detail | If the inbound record maps to measurement_concept_id = (Body mass index) and unit maps to any of these: 'kilogram per square meter', 'No matching concept', 'kilogram', 'square meter', then set the unit_concept_id to 9531 (kilogram per square meter). Otherwise, match to the JNJ_UNITS STCM. If no match is found, set this field to 0.| |
 | unit_source_value | measurement_detail | | |
 | range_high | |  | | 
 | range_low |  | | |

--- a/docs/OPTUM_PANTHER/Optum_Panther_insurance.md
+++ b/docs/OPTUM_PANTHER/Optum_Panther_insurance.md
@@ -1,10 +1,9 @@
 ---
 layout: default
-title: Immunizations
+title: Insurance
 nav_order: 20
-parent: Optum EHR to STEM
-grand_parent: Optum EHR
-description: "OPTUM EHR Immunzations table to STEM"
+parent: Optum EHR
+description: "OPTUM EHR Insurance table to Observation"
 ---
 
 # CDM Table name: Observation
@@ -284,3 +283,8 @@ Note, the observation_concept_id belong to Payer domain, but goes to Observation
    </td>
   </tr>
 </table>
+
+## Change log
+
+### 13-Nov-2023
+Set proper header.

--- a/docs/Optum Clinformatics/Optum_med_claims_to_STEM.md
+++ b/docs/Optum Clinformatics/Optum_med_claims_to_STEM.md
@@ -42,15 +42,15 @@ Records will be written from the **MEDICAL_CLAIMS** table mapping the field **RV
 | operator_concept_id | |||
 | unit_concept_id | |||
 | unit_source_value | |||
-| start_date | **VISIT_DETAIL** VISIT_DETAIL_START_DATE||| 
-| end_date | |||
+| start_date | **VISIT_DETAIL** VISIT_DETAIL_START_DATE, for drugs - fst_dt||| 
+| end_date | **VISIT_DETAIL** VISIT_DETAIL_END_DATE, for drugs - fst_dt |||
 | range_high | |||
 | range_low | |||
 | value_as_number | |||
 | value_as_string | |||
 | value_as_concept_id | |||
 | value_source_value | |||
-| end_datetime | |||
+| end_datetime | **VISIT_DETAIL** VISIT_DETAIL_START_DATETIME, for drugs - fst_dt |||
 | verbatim_end_date | |||
 | days_supply | |If record is created using **MEDICAL_CLAIMS**<br/>NDC set days_supply to 1||
 | dose_unit_source_value |**NDC**<br>**MEDICAL_CLAIMS** NDC_UOM |||
@@ -71,3 +71,8 @@ Records will be written from the **MEDICAL_CLAIMS** table mapping the field **RV
 | disease_status_source_value | |||
 | condition_status_concept_id | |||
 | condition_status_source_value | |||
+
+## Change log
+
+### 13-Nov-2023
+Set drug start and end dates as fst_dt - dates are extracted from the med_claims table itself


### PR DESCRIPTION
Some small inaccuracies and proper dates logic in Optum extended: use the rx_claims and medical_claims dates instead of visit_detail dates