### PR TITLE
Update CCAE_MDCR_cost.md

### DIFF
--- a/docs/IBM_CCAE_MDCR/CCAE_MDCR_cost.md
+++ b/docs/IBM_CCAE_MDCR/CCAE_MDCR_cost.md
@@ -113,6 +113,7 @@ The **COST** table captures all cost information.
 | REVENUE_CODE_SOURCE_VALUE | - | - | - |
 | DRG_CONCEPT_ID | - | 0 | - |
 | DRG_SOURCE_VALUE | - | - | - |
+
 <br>
 
 
@@ -145,6 +146,7 @@ The **COST** table captures all cost information.
 | REVENUE_CODE_SOURCE_VALUE | - | - | - |
 | DRG_CONCEPT_ID | - | 0 | - |
 | DRG_SOURCE_VALUE | - | - | - |
+
 <br>
 
 


### PR DESCRIPTION
I have added new line between bottom of the table and br tag, otherwise table are broken in html.

It looks good on .md but Jekyll that render .md document to html shows like below:
![image](https://github.com/OHDSI/ETL-LambdaBuilder/assets/13117785/84d97445-7c5a-40c1-9de7-eeb41c14fb7b)

https://ohdsi.github.io/ETL-LambdaBuilder/IBM_CCAE_MDCR/CCAE_MDCR_cost.html

