### PR TITLE
Optum rx updates

### DIFF
--- a/docs/OPTUM_PANTHER/Optum_Panther_Drug_Exposure.md
+++ b/docs/OPTUM_PANTHER/Optum_Panther_Drug_Exposure.md
@@ -21,7 +21,7 @@ We apply this imputation strategy after data has been moved to the DRUG_EXPOSURE
 
 <ins>**Optum EHR Days Supply Filtering**</ins> <br>
 Some records from source tables for cdm.DRUG_EXPOSURE have very high days_supply values, which are likely inaccurate (most states in the US require prescriptions to be renewed at least annually). 
-Reocrds with days_supply > 365 are excluded from cdm.DRUG_EXPOSURE.
+Reocrds with days_supply >= 365 are excluded from cdm.DRUG_EXPOSURE.
 
 ## Table name: drug_exposure
 

--- a/docs/OPTUM_PANTHER/Optum_Panther_Drug_Exposure.md
+++ b/docs/OPTUM_PANTHER/Optum_Panther_Drug_Exposure.md
@@ -19,6 +19,10 @@ Code he uses to do this: https://github.com/schuemie/MethodsLibraryPleEvaluation
 
 We apply this imputation strategy after data has been moved to the DRUG_EXPOSURE table from the STEM table as detailed below. Once completed the DRUG_ERA logic is run to create DRUG_ERAs using the imputed dates.
 
+**Optum EHR Days Supply Filtering**
+Some records from source tables for cdm.DRUG_EXPOSURE have very high days_supply values, which are likely inaccurate (most states in the US require prescriptions to be renewed at least annually). 
+Reocrds with days_supply > 365 are excluded from cdm.DRUG_EXPOSURE.
+
 ## Table name: drug_exposure
 
 | Destination Field | Source field | Logic | Comment field |

--- a/docs/OPTUM_PANTHER/Optum_Panther_Drug_Exposure.md
+++ b/docs/OPTUM_PANTHER/Optum_Panther_Drug_Exposure.md
@@ -19,7 +19,7 @@ Code he uses to do this: https://github.com/schuemie/MethodsLibraryPleEvaluation
 
 We apply this imputation strategy after data has been moved to the DRUG_EXPOSURE table from the STEM table as detailed below. Once completed the DRUG_ERA logic is run to create DRUG_ERAs using the imputed dates.
 
-**Optum EHR Days Supply Filtering**
+<ins>**Optum EHR Days Supply Filtering**</ins> <br>
 Some records from source tables for cdm.DRUG_EXPOSURE have very high days_supply values, which are likely inaccurate (most states in the US require prescriptions to be renewed at least annually). 
 Reocrds with days_supply > 365 are excluded from cdm.DRUG_EXPOSURE.
 


### PR DESCRIPTION
Hi Anton,

There are some records in Optum EHR cdm.drug_exposure with very high days_supply (7000, etc.). Clair has done some additional research, and it is unlikely that any prescriptions with a days_supply >= 365 are correct due to laws around prescribing in the US. 

Here is the wrike task discussing this further: https://www.wrike.com/open.htm?id=874235497

To clean up this data, can we please remove all records from cdm.drug_exposure where days_supply >= 365, and update the ETL to exclude these records in the future?

Please let me know if you have any questions!

Sarah